### PR TITLE
 Changes to be committed:add relative path support.

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+    publicPath:'./',
+    configureWebpack:{
+        resolve: {
+            alias: {
+              'assets': '@/assets',
+              'common': '@/common',
+              'components': '@/components',
+              'network': '@/network',
+              'views': '@/views',
+              'plugins': '@/plugins',
+            }
+          }
+    }
+}


### PR DESCRIPTION
	new file:   vue.config.js
add relative path support.
Now you can copy dist dir to any web server dir after you exec npm run build.
All asset path will be correct.

支持相对路径部署。
执行 npm run build 之后
你可以把dist目录复制到任意Web服务器的任意路径下，照样能工作。
适合实际的部署环境。