### PR TITLE
fix: move font setting from #app to body

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -31,10 +31,12 @@ export default {
 </script>
 
 <style>
-#app {
+body {
   font-family: Avenir, Helvetica, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+#app {
   text-align: center;
   color: #2c3e50;
   margin-top: 60px;


### PR DESCRIPTION
Applies suggested fix to https://github.com/element-plus/element-plus/issues/2604 to the starter template.